### PR TITLE
Add support for commutative property for vectors

### DIFF
--- a/Utils/Vec2.h
+++ b/Utils/Vec2.h
@@ -111,6 +111,11 @@ std::ostream & operator<<(std::ostream & os, const Vec2t<T> & v) {
    return os;
 }
 
+template <typename T>
+Vec2t<T> operator*(float scalar, const Vec2t<T>& vec) {
+  return vec * scalar;
+}
+
 typedef Vec2t<float> Vec2;
 typedef Vec2t<int32_t> Vec2i;
 typedef Vec2t<uint32_t> Vec2ui;

--- a/Utils/Vec3.h
+++ b/Utils/Vec3.h
@@ -211,6 +211,11 @@ std::ostream & operator<<(std::ostream & os, const Vec3t<T> & v) {
    return os;
 }
 
+template <typename T>
+Vec3t<T> operator*(float scalar, const Vec3t<T>& vec) {
+  return vec * scalar;
+}
+
 typedef Vec3t<float> Vec3;
 typedef Vec3t<int32_t> Vec3i;
 typedef Vec3t<uint32_t> Vec3ui;

--- a/Utils/Vec4.h
+++ b/Utils/Vec4.h
@@ -156,6 +156,12 @@ std::ostream & operator<<(std::ostream & os, const Vec4t<T> & v) {
    os << v.toString();
    return os;
 }
+
+template <typename T>
+Vec4t<T> operator*(float scalar, const Vec4t<T>& vec) {
+  return vec * scalar;
+}
+
 typedef Vec4t<float> Vec4;
 typedef Vec4t<int32_t> Vec4i;
 typedef Vec4t<uint32_t> Vec4ui;


### PR DESCRIPTION
Add support for calculations in order of:
```c++
float a = 1.0f;
Vec2 v = Vec2{1.0f, 2.0f};
Vec2 result = a * v;
```
as well as:
```c++
Vec2 v = Vec2{1.0f, 2.0f};
Vec2 result = 1.0f * v;
```

Calculation is based on already defined scalar multiplication in the order of `vector * scalar`.

Added for types `Vec2`, `Vec3` and `Vec4`.